### PR TITLE
feat: better sentry error reporting

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -33,7 +33,7 @@ export const createApp = (): { app: Express; router: express.Router } => {
       ],
       tracesSampleRate: 1.0,
       ignoreErrors: [
-        /Transmitter .+ not found/,
+        /Transmitter(?: .+)? not found/,
         /^Failed to fetch strands$/,
         /Drive with id .+ not found/,
         /Document with id .+ not found/,
@@ -79,8 +79,9 @@ export const createApp = (): { app: Express; router: express.Router } => {
     res.setHeader('Content-Type', 'text/html');
     const basePath =
       process.env.BASE_PATH === '/' ? '' : process.env.BASE_PATH || '';
-    const endpoint = `${basePath}${req.params.driveId !== undefined ? `/d/${req.params.driveId}` : '/drives'
-      }`;
+    const endpoint = `${basePath}${
+      req.params.driveId !== undefined ? `/d/${req.params.driveId}` : '/drives'
+    }`;
     res.send(
       renderPlaygroundPage({
         endpoint: endpoint,

--- a/api/src/graphql/server/index.ts
+++ b/api/src/graphql/server/index.ts
@@ -17,7 +17,7 @@ function loggerPlugin(): ApolloServerPlugin<Context> {
       return {
         async didEncounterErrors(c) {
           c.errors?.forEach((e) => {
-            c.contextValue.apolloLogger.error({ error: e }, e.message);
+            c.contextValue.apolloLogger.error({ err: e }, e.message);
           });
         },
       };


### PR DESCRIPTION
Better ignore regex for transmitter not found.
https://powerhouse-u6.sentry.io/issues/5529616831/events/4cca85fa2e164da48560b6669011f2a4/

Also fixes no stack trace on appolo errors.

Adds more depth to the error json so it will show in Sentry. 
<img width="463" alt="Screenshot 2024-07-22 at 12 08 49" src="https://github.com/user-attachments/assets/14b1b3a8-da40-4f6d-b7cb-1fdf65cda19c">

This has to be done for the other child loggers.
At least Prisma and Document drive are not passing the error with the stack trace.
https://powerhouse-u6.sentry.io/issues/5164067350/events/46138a98c5b24808a52aef827970aef2/
https://powerhouse-u6.sentry.io/issues/5204910938/events/eed78d83aca744b481c127234c4e9ef8/